### PR TITLE
Add build command to verify local fork

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -105,6 +105,7 @@ This is the **recommended approach** to develop on Katana - it keeps state local
   In a new terminal, verify your local fork is working:
 
   ```sh
+  bun run build:addressutils
   bun run verify:anvil
   ```
 


### PR DESCRIPTION
# Issue: 
- `bun run verify:anvil` will fail with error: "Cannot find module './mapping'", without executing `bun run build:addressutils`. The command: `verify:anvil` executes `scripts/verify_anvil.js`, which requires the `mappings.ts` file to exist in the same folder.

# Change: 
- add `bun run build:addressutils` to the quickstart documentation.